### PR TITLE
Add a years field to schema

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,10 +7,12 @@ AllCops:
     - 'db/**/*'
     - 'node_modules/**/*'
     - 'vendor/**/*'
+    - 'tmp/**/*'
 
 Metrics/BlockLength:
   Exclude:
     - lib/tasks/*
+    - spec/graphql/*
 
 Metrics/LineLength:
   Max: 120

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'fabrication'
+  gem 'pry'
   gem 'rspec-rails'
   gem 'rubocop'
   gem 'rubocop-performance'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,7 @@ GEM
     chromedriver-helper (2.1.1)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -175,6 +176,9 @@ GEM
     parser (2.6.2.1)
       ast (~> 2.4.0)
     pg (1.1.4)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     psych (3.1.0)
     public_suffix (3.0.3)
     puma (3.12.1)
@@ -312,6 +316,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   mini_magick
   pg (>= 0.18, < 2.0)
+  pry
   puma
   rails (~> 5.2.0)
   rspec-rails

--- a/app/graphql/types/project_year_type.rb
+++ b/app/graphql/types/project_year_type.rb
@@ -1,0 +1,6 @@
+module Types
+  class ProjectYearType < Types::BaseObject
+    field :year, Integer, 'Year', null: false
+    field :projects, [ProjectType], 'Projects for this year', null: false
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -56,5 +56,18 @@ module Types
     def image(id:)
       Slide.find(id).image
     end
+
+    field :years, [ProjectYearType], null: true do
+      description 'All years for which there exist projects'
+    end
+
+    def years
+      Project.unscoped.select('distinct year').order('year desc').map(&:year).map do |year|
+        {
+          year: year,
+          projects: Project.unscoped.where(year: year).order(month: :desc)
+        }
+      end
+    end
   end
 end

--- a/app/graphql/types/slide_type.rb
+++ b/app/graphql/types/slide_type.rb
@@ -9,8 +9,6 @@ module Types
     field :project, ProjectType, 'Project for this slide', null: false
     field :image, ImageType, 'Attached image', null: true
 
-    def image
-      object.image
-    end
+    delegate :image, to: :object
   end
 end

--- a/spec/graphql/portfolio18_schema_spec.rb
+++ b/spec/graphql/portfolio18_schema_spec.rb
@@ -1,0 +1,124 @@
+require 'rails_helper'
+
+RSpec.describe Portfolio18Schema do
+  let(:context) { {} }
+  let(:variables) { {} }
+
+  let(:result) do
+    res = Portfolio18Schema.execute(
+      query_string,
+      context: context,
+      variables: variables
+    )
+    # Print any errors
+    pp res if res['errors']
+    res
+  end
+
+  let!(:client1) { Fabricate(:client, name: 'The Museum') }
+  let!(:project1) { Fabricate(:project, title: 'The Show', client: client1, year: 2016, month: 3) }
+  let!(:slide1) { Fabricate(:slide, caption: 'New slide', project: project1) }
+
+  let!(:client2) { Fabricate(:client, name: 'The Press', abbr: 'p') }
+  let!(:project2) { Fabricate(:project, title: 'The Book', client: client2, year: 2015, month: 9) }
+  let!(:slide2) { Fabricate(:slide, caption: 'Old slide', project: project2) }
+
+  describe 'clients query' do
+    let(:query_string) do
+      <<~QUERY
+        {
+          clients {
+            name
+            projects {
+              title
+              slides {
+                caption
+              }
+            }
+          }
+        }
+      QUERY
+    end
+
+    let(:expected) do
+      {
+        'clients' => [
+          {
+            'name' => 'The Museum',
+            'projects' => [
+              {
+                'title' => 'The Show',
+                'slides' => [{ 'caption' => 'New slide' }]
+              },
+            ]
+          },
+          {
+            'name' => 'The Press',
+            'projects' => [
+              {
+                'title' => 'The Book',
+                'slides' => [{ 'caption' => 'Old slide' }]
+              },
+            ]
+          },
+        ]
+      }
+    end
+
+    it 'can return projects grouped by client' do
+      expect(result['data']).to eq(expected)
+    end
+  end
+
+  describe 'years query' do
+    let(:query_string) do
+      <<~QUERY
+        {
+          years {
+            year
+            projects {
+              client {
+                name
+              }
+              title
+              slides {
+                caption
+              }
+            }
+          }
+        }
+      QUERY
+    end
+
+    let(:expected) do
+      {
+        'years' => [
+          {
+            'year' => 2016,
+            'projects' => [
+              {
+                'title' => 'The Show',
+                'client' => { 'name' => 'The Museum' },
+                'slides' => [{ 'caption' => 'New slide' }]
+              },
+            ]
+          },
+          {
+            'year' => 2015,
+            'projects' => [
+              {
+                'title' => 'The Book',
+                'client' => { 'name' => 'The Press' },
+                'slides' => [{ 'caption' => 'Old slide' }]
+              },
+            ]
+          },
+        ]
+      }
+    end
+
+    it 'can return projects grouped by year' do
+      expect(result['data']).to eq(expected)
+    end
+  end
+end


### PR DESCRIPTION
Enables:

```graphql
{
  years {
    year
    projects {
      title
    }
  }
}
```

And to test, this adds an integration spec for the GraphQL schema as well.