### PR TITLE
Cache simple responses

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -2,14 +2,7 @@ class GraphqlController < ApplicationController
   skip_forgery_protection
 
   def execute
-    variables = ensure_hash(params[:variables])
-    query = params[:query]
-    operation_name = params[:operationName]
-    context = {
-      # Query context goes here, for example:
-      # current_user: current_user,
-    }
-    result = Portfolio18Schema.execute(query, variables: variables, context: context, operation_name: operation_name)
+    result = fresh_or_cached_results
     render json: result
   rescue StandardError => e
     raise e unless Rails.env.development?
@@ -18,6 +11,37 @@ class GraphqlController < ApplicationController
   end
 
   private
+
+  def fresh_or_cached_results
+    if cacheable?
+      Rails.cache.fetch(cache_key, expires_in: Rails.application.config_for(:cache)['ttl']) do
+        Portfolio18Schema.execute(*query_parameters).to_h
+      end
+    else
+      Portfolio18Schema.execute(*query_parameters)
+    end
+  end
+
+  def query_parameters
+    [
+      params[:query],
+      {
+        variables: ensure_hash(params[:variables]),
+        operation_name: params[:operationName],
+        context: {
+          # e.g. current_user: current_user,
+        }
+      },
+    ]
+  end
+
+  def cacheable?
+    params[:context].blank? && params[:operation_name].blank?
+  end
+
+  def cache_key
+    [params[:query], params[:variables].to_s].map { |s| Digest::MD5.hexdigest(s) }.join('/')
+  end
 
   # Handle form data, JSON body, or a blank value
   def ensure_hash(ambiguous_param)

--- a/config/cache.yml
+++ b/config/cache.yml
@@ -1,0 +1,11 @@
+
+default: &default
+  ttl: <%= ENV['CACHE_TTL'] || 1.hour %>
+
+development:
+  <<: *default
+  ttl: <%= ENV['CACHE_TTL'] || 1.minute %>
+
+production:
+  <<: *default
+  ttl: <%= ENV['CACHE_TTL'] || 1.day %>


### PR DESCRIPTION
Query responses won't be cached if they contain a context (e.g. user info) or if they contain a mutation.

Only simpler queries (query + variables) will be cached.

Cache TTL is configurable via env var. Using in-memory caching by default -- something to improve later.