### PR TITLE
Add slugs to Client and Project models and to gql schema

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'puma'
 gem 'rails', '~> 5.2.0'
 gem 'sass-rails'
 gem 'shrine'
+gem 'stringex'
 gem 'uglifier'
 gem 'webpacker', '~> 4.x'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,6 +274,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    stringex (2.8.5)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
@@ -325,6 +326,7 @@ DEPENDENCIES
   sass-rails
   selenium-webdriver
   shrine
+  stringex
   uglifier
   web-console
   webpacker (~> 4.x)

--- a/app/graphql/types/client_type.rb
+++ b/app/graphql/types/client_type.rb
@@ -1,6 +1,7 @@
 module Types
   class ClientType < Types::BaseObject
     field :id, ID, null: false
+    field :slug, String, 'Slug', null: false
     field :name, String, 'Full name', null: false
     field :abbr, String, 'Short code, up to 4 letters', null: false
     field :projects, ProjectType.connection_type, 'Projects for this client', max_page_size: 100, null: false

--- a/app/graphql/types/project_type.rb
+++ b/app/graphql/types/project_type.rb
@@ -1,6 +1,7 @@
 module Types
   class ProjectType < Types::BaseObject
     field :id, ID, null: false
+    field :slug, String, 'Slug', null: false
     field :title, String, 'Main title', null: false
     field :subtitle, String, 'Subtitle', null: true
     field :year, Integer, 'Completion year', null: false

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -1,4 +1,5 @@
 class Client < ApplicationRecord
+  acts_as_url :name, url_attribute: :slug, sync_url: true
   has_many :projects, dependent: :destroy
   has_many :slides, through: :projects
   default_scope { order(name: :asc) }

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,4 +1,5 @@
 class Project < ApplicationRecord
+  acts_as_url :title, url_attribute: :slug, sync_url: true
   belongs_to :client
   has_many :slides, dependent: :destroy
   default_scope { order(year: :desc, month: :desc) }

--- a/db/migrate/20190419154406_add_slug_to_client.rb
+++ b/db/migrate/20190419154406_add_slug_to_client.rb
@@ -1,0 +1,5 @@
+class AddSlugToClient < ActiveRecord::Migration[5.2]
+  def change
+    add_column :clients, :slug, :string
+  end
+end

--- a/db/migrate/20190419155458_add_slug_to_project.rb
+++ b/db/migrate/20190419155458_add_slug_to_project.rb
@@ -1,0 +1,5 @@
+class AddSlugToProject < ActiveRecord::Migration[5.2]
+  def change
+    add_column :projects, :slug, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_13_021804) do
+ActiveRecord::Schema.define(version: 2019_04_19_155458) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2019_04_13_021804) do
     t.string "abbr", limit: 4, default: "", null: false
     t.datetime "created_on"
     t.datetime "updated_on"
+    t.string "slug"
     t.index ["abbr"], name: "idx_16615_clients_abbr_index", unique: true
   end
 
@@ -33,6 +34,7 @@ ActiveRecord::Schema.define(version: 2019_04_13_021804) do
     t.boolean "visible", default: false
     t.datetime "created_on"
     t.datetime "updated_on"
+    t.string "slug"
   end
 
   create_table "slides", force: :cascade do |t|

--- a/spec/graphql/portfolio18_schema_spec.rb
+++ b/spec/graphql/portfolio18_schema_spec.rb
@@ -209,4 +209,88 @@ RSpec.describe Portfolio18Schema do
       expect(result['data']).to eq(expected)
     end
   end
+
+  describe 'client query' do
+    let(:query_string) do
+      <<~QUERY
+        {
+          client(slug: "the-museum") {
+            name
+          }
+        }
+      QUERY
+    end
+
+    let(:expected) do
+      {
+        "client": {
+          "name": 'The Museum'
+        }
+      }.with_indifferent_access
+    end
+
+    it 'can find by slug' do
+      expect(result['data']).to eq(expected)
+    end
+
+    context 'when slug and id are both supplied' do
+      let(:query_string) do
+        <<~QUERY
+          {
+            client(slug: "the-museum", id: 42) {
+              name
+            }
+          }
+        QUERY
+      end
+
+      it 'returns an error' do
+        expect do
+          Portfolio18Schema.execute(query_string)
+        end.to raise_error RuntimeError, /not both/
+      end
+    end
+  end
+
+  describe 'project query' do
+    let(:query_string) do
+      <<~QUERY
+        {
+          project(slug: "the-show") {
+            title
+          }
+        }
+      QUERY
+    end
+
+    let(:expected) do
+      {
+        "project": {
+          "title": 'The Show'
+        }
+      }.with_indifferent_access
+    end
+
+    it 'can find by slug' do
+      expect(result['data']).to eq(expected)
+    end
+
+    context 'when slug and id are both supplied' do
+      let(:query_string) do
+        <<~QUERY
+          {
+            project(slug: "the-show", id: 42) {
+              title
+            }
+          }
+        QUERY
+      end
+
+      it 'returns an error' do
+        expect do
+          Portfolio18Schema.execute(query_string)
+        end.to raise_error RuntimeError, /not both/
+      end
+    end
+  end
 end


### PR DESCRIPTION
Using [stringex](https://github.com/rsl/stringex) gem, which is good at i18n but does not offer slug history out of the box.